### PR TITLE
[#290] Feature: 업로드 시간 빠른 설정 API 구현

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -140,7 +140,7 @@ public class PostController {
 		return ResponseEntity.ok().build();
 	}
 
-	@Operation(summary = "업로드 시간 빠른 예약하기 API", description = "포스트 수, 업로드 시작 시간, 시간대, postGroupId를 받아 READY_TO_UPLOAD 상태인 Post의 예약 시간을 일괄로 확정합니다.")
+	@Operation(summary = "업로드 시간 빠른 예약하기 API", description = "READY_TO_UPLOAD 상태인 Post들의 예약 시간을 일괄로 설정합니다.")
 	@PutMapping("/post-groups/{postGroupId}/posts/reserved-all")
 	public ResponseEntity<GetAgentReservedPostsResponse> reserveReadyToUploadPosts(
 		@PathVariable Long agentId,

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -263,7 +263,7 @@ public class PostController {
 
 	@Operation(
 		summary = "계정별 예약 게시물 조회 API",
-		description = "sns 계정별 업로드가 예약된 상태(UPLOAD_RESERVED)인 게시물 목록을 조회합니다."
+		description = "sns 계정별 업로드가 예약된 상태(UPLOAD_CONFIRMED)인 게시물 목록을 조회합니다."
 	)
 	@GetMapping("/post-groups/posts/upload-reserved")
 	public ResponseEntity<GetAgentReservedPostsResponse> getAgentReservedPosts(

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.mainapp.domain.post.controller.request.CreatePostsRequest;
 import org.mainapp.domain.post.controller.request.MultiplePostUpdateRequest;
+import org.mainapp.domain.post.controller.request.ReserveUploadTimeRequest;
 import org.mainapp.domain.post.controller.request.SinglePostUpdateRequest;
 import org.mainapp.domain.post.controller.request.UpdatePostContentRequest;
 import org.mainapp.domain.post.controller.request.UpdatePostsMetadataRequest;
@@ -137,6 +138,16 @@ public class PostController {
 	) {
 		postService.updateReservedPostsUploadTime(agentId, updateReservedPostsRequest);
 		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "업로드 시간 빠른 예약하기 API", description = "포스트 수, 업로드 시작 시간, 시간대, postGroupId를 받아 READY_TO_UPLOAD 상태인 Post의 예약 시간을 일괄로 확정합니다.")
+	@PutMapping("/post-groups/{postGroupId}/posts/reserved-all")
+	public ResponseEntity<GetAgentReservedPostsResponse> reserveReadyToUploadPosts(
+		@PathVariable Long agentId,
+		@PathVariable Long postGroupId,
+		@Validated @RequestBody ReserveUploadTimeRequest request
+	) {
+		return ResponseEntity.ok(postService.reserveReadyToUploadPosts(agentId, postGroupId, request));
 	}
 
 	@Operation(summary = "게시물 프롬프트 기반 개별 수정 API", description = "개별 게시물에 대해 입력된 프롬프트를 바탕으로 수정합니다.")

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/request/ReserveUploadTimeRequest.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/request/ReserveUploadTimeRequest.java
@@ -1,6 +1,6 @@
 package org.mainapp.domain.post.controller.request;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import org.domainmodule.post.entity.type.UploadTimeType;
 
@@ -12,9 +12,9 @@ public record ReserveUploadTimeRequest(
 	@Schema(description = "하루에 업로드 할 글의 수", example = "2")
 	@NotNull(message = "업로드 할 글의 수를 지정해주세요.")
 	int dailyUploadCount,
-	@Schema(description = "업로드 시작 시간", example = "2025-01-01T00:00:00.000Z")
-	@NotNull(message = "업로드 시작 시간을 지정해주세요.")
-	LocalDateTime uploadStartTime,
+	@Schema(description = "업로드 시작 시간", example = "2025-01-01")
+	@NotNull(message = "업로드 시작 날짜을 지정해주세요.")
+	LocalDate uploadStartDate,
 	@Schema(description = "업로드 할 시간대", example = "MORNING")
 	@NotNull(message = "업로드 할 시간대를 지정해주세요.")
 	UploadTimeType uploadTimeType

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/request/ReserveUploadTimeRequest.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/request/ReserveUploadTimeRequest.java
@@ -1,0 +1,22 @@
+package org.mainapp.domain.post.controller.request;
+
+import java.time.LocalDateTime;
+
+import org.domainmodule.post.entity.type.UploadTimeType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "게시물 업로드 시간 예약하기 요청 본문")
+public record ReserveUploadTimeRequest(
+	@Schema(description = "하루에 업로드 할 글의 수", example = "2")
+	@NotNull(message = "업로드 할 글의 수를 지정해주세요.")
+	int dailyUploadCount,
+	@Schema(description = "업로드 시작 시간", example = "2025-01-01T00:00:00.000Z")
+	@NotNull(message = "업로드 시작 시간을 지정해주세요.")
+	LocalDateTime uploadStartTime,
+	@Schema(description = "업로드 할 시간대", example = "MORNING")
+	@NotNull(message = "업로드 할 시간대를 지정해주세요.")
+	UploadTimeType uploadTimeType
+) {
+}

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
@@ -293,9 +293,13 @@ public class PostService {
 		List<Post> readyToUploadPosts = postRepository.findPostsByUserAndAgentAndStatus(
 			userId, agentId, postGroupId, PostStatusType.READY_TO_UPLOAD);
 
-		// 해당 Agent의 이미 예약 시간 확정 + 업로드 대기 상태 글
-		List<Post> confirmedUploadPosts = postRepository.findAllReservedPostsByUserAndAgent(
-			userId, agentId, PostStatusType.UPLOAD_CONFIRMED);
+		// 해당 Agent의 이미 예약 시간 확정 + 업로드 대기 상태인 글
+		List<PostStatusType> postStatusTypeList = List.of(
+			PostStatusType.UPLOAD_RESERVED,
+			PostStatusType.UPLOAD_CONFIRMED
+		);
+		List<Post> confirmedUploadPosts = postRepository.findAllReservedPostsByUserAndAgentAndStatus(
+			userId, agentId, postStatusTypeList);
 
 		// 하루에 업로드할 개수, 업로드 시작 날짜, 업로드할 전체
 		int dailyUploadCount = request.dailyUploadCount();

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
@@ -293,7 +293,7 @@ public class PostService {
 		List<Post> readyToUploadPosts = postRepository.findPostsByUserAndAgentAndStatus(
 			userId, agentId, postGroupId, PostStatusType.READY_TO_UPLOAD);
 
-		// 해당 Agent의 이미 예약 시간 확정 글
+		// 해당 Agent의 이미 예약 시간 확정 + 업로드 대기 상태 글
 		List<Post> confirmedUploadPosts = postRepository.findAllReservedPostsByUserAndAgent(
 			userId, agentId, PostStatusType.UPLOAD_CONFIRMED);
 
@@ -326,7 +326,7 @@ public class PostService {
 		for (int i = 0; i < totalPosts; i++) {
 			Post post = readyToUploadPosts.get(i);
 			post.updateUploadTime(randomAvailableTimes.get(i));
-			post.updateStatus(PostStatusType.UPLOAD_CONFIRMED);
+			post.updateStatus(PostStatusType.UPLOAD_RESERVED);
 		}
 
 		// 변경된 post 저장
@@ -419,8 +419,11 @@ public class PostService {
 	 */
 	private void validateDeletingPostStatus(Post post) {
 		// 삭제 가능한 상태: 생성됨, 수정중, 수정완료
-		List<PostStatusType> validStatuses = List.of(PostStatusType.GENERATED, PostStatusType.EDITING,
-			PostStatusType.READY_TO_UPLOAD);
+		List<PostStatusType> validStatuses = List.of(
+			PostStatusType.GENERATED,
+			PostStatusType.EDITING,
+			PostStatusType.READY_TO_UPLOAD,
+			PostStatusType.UPLOAD_RESERVED);
 
 		if (!validStatuses.contains(post.getStatus())) {
 			throw new CustomException(PostErrorCode.INVALID_DELETING_POST_STATUS);
@@ -433,7 +436,7 @@ public class PostService {
 	public GetAgentReservedPostsResponse getAgentReservedPosts(Long agentId) {
 		Long userId = SecurityUtil.getCurrentUserId();
 		List<Post> posts = postRepository.findAllReservedPostsByUserAndAgent(userId, agentId,
-			PostStatusType.UPLOAD_RESERVED);
+			PostStatusType.UPLOAD_CONFIRMED);
 
 		return GetAgentReservedPostsResponse.from(posts);
 	}

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
@@ -299,7 +299,7 @@ public class PostService {
 
 		// 하루에 업로드할 개수, 업로드 시작 날짜, 업로드할 전체
 		int dailyUploadCount = request.dailyUploadCount();
-		LocalDate startDate = request.uploadStartTime().toLocalDate();
+		LocalDate startDate = request.uploadStartDate();
 		int totalPosts = readyToUploadPosts.size();
 
 		// 업로드할 시간대 범위 가져오기

--- a/domain/domain-module/src/main/java/org/domainmodule/post/entity/type/PostStatusType.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/entity/type/PostStatusType.java
@@ -1,5 +1,17 @@
 package org.domainmodule.post.entity.type;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum PostStatusType {
-	GENERATED, EDITING, READY_TO_UPLOAD, UPLOAD_RESERVED, UPLOADED, UPLOAD_FAILED
+	GENERATED("생성 됨"),
+	EDITING("수정 중"),
+	READY_TO_UPLOAD("업로드 준비 완료"),
+	UPLOAD_RESERVED("업로드 대기"),
+	UPLOAD_CONFIRMED("업로드 확정"),
+	UPLOADED("업로드 완료"),
+	UPLOAD_FAILED("업로드 실패");
+	private final String value;
 }

--- a/domain/domain-module/src/main/java/org/domainmodule/post/entity/type/UploadTimeType.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/entity/type/UploadTimeType.java
@@ -1,0 +1,21 @@
+package org.domainmodule.post.entity.type;
+
+import java.time.LocalTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UploadTimeType {
+	MORNING("오전", LocalTime.of(9, 0), LocalTime.of(11, 0)),
+	LUNCH("점심", LocalTime.of(11, 0), LocalTime.of(13, 0)),
+	AFTERNOON("오후", LocalTime.of(13, 0), LocalTime.of(17, 0)),
+	EVENING("저녁", LocalTime.of(17, 0), LocalTime.of(21, 0)),
+	NIGHT("밤", LocalTime.of(21, 0), LocalTime.of(1, 0)),
+	RANDOM("전체 선택", null, null); // 무작위 업로드
+
+	private final String label;
+	private final LocalTime startTime;
+	private final LocalTime endTime;
+}

--- a/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
@@ -84,7 +84,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		""")
 	Optional<Post> findLastGeneratedPost(PostGroup postGroup, PostStatusType status);
 
-	// userId, Agent, PostGroup, 특정 status를 가진 모든 Post조회
+	// Agen 게시글 중, 특정 status를 가진 모든 Post를 uploadTime 오름차순으로 조회
 	@Query("""
 		    SELECT p FROM Post p
 		    JOIN FETCH p.postGroup pg
@@ -94,7 +94,25 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		    AND p.status = :status
 		    ORDER BY p.uploadTime
 		""")
-	List<Post> findAllReservedPostsByUserAndAgent(@Param("userId") Long userId,
+	List<Post> findAllReservedPostsByUserAndAgent(
+		@Param("userId") Long userId,
 		@Param("agentId") Long agentId,
+		@Param("status") PostStatusType status);
+
+	// user, agent, postgroup, 특정 status를 가진 post를 displayOrder 오름차순 순서로 조회
+	@Query("""
+    SELECT p FROM Post p
+    JOIN p.postGroup pg
+    JOIN pg.agent a
+    WHERE a.user.id = :userId
+    AND a.id = :agentId
+    AND p.status = :status
+    AND pg.id = :postGroupId
+    ORDER BY p.displayOrder ASC
+    """)
+	List<Post> findPostsByUserAndAgentAndStatus(
+		@Param("userId") Long userId,
+		@Param("agentId") Long agentId,
+		@Param("postGroupId") Long postGroupId,
 		@Param("status") PostStatusType status);
 }

--- a/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
@@ -99,7 +99,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		@Param("agentId") Long agentId,
 		@Param("status") PostStatusType status);
 
-	// user, agent, postgroup, 특정 status를 가진 post를 displayOrder 오름차순 순서로 조회
+	// user, agent, postgroup, status를 가진 post를 displayOrder 오름차순 순서로 조회
 	@Query("""
     SELECT p FROM Post p
     JOIN p.postGroup pg
@@ -115,4 +115,18 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		@Param("agentId") Long agentId,
 		@Param("postGroupId") Long postGroupId,
 		@Param("status") PostStatusType status);
+
+	@Query("""
+    SELECT p FROM Post p
+    JOIN p.postGroup pg
+    JOIN pg.agent a
+    WHERE a.user.id = :userId
+    AND a.id = :agentId
+    AND p.status IN :statusList
+    ORDER BY p.uploadTime
+    """)
+	List<Post> findAllReservedPostsByUserAndAgentAndStatus(
+		@Param("userId") Long userId,
+		@Param("agentId") Long agentId,
+		@Param("statusList") List<PostStatusType> statusList);
 }

--- a/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
@@ -84,11 +84,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		""")
 	Optional<Post> findLastGeneratedPost(PostGroup postGroup, PostStatusType status);
 
-	// Agen 게시글 중, 특정 status를 가진 모든 Post를 uploadTime 오름차순으로 조회
+	// Agent 게시글 중, 특정 status를 가진 모든 Post를 uploadTime 오름차순으로 조회
 	@Query("""
 		    SELECT p FROM Post p
-		    JOIN FETCH p.postGroup pg
-		    JOIN FETCH pg.agent a
+		    JOIN p.postGroup pg
+		    JOIN pg.agent a
 		    WHERE a.user.id = :userId
 		    AND a.id = :agentId
 		    AND p.status = :status


### PR DESCRIPTION
## 🌱 관련 이슈
- close #290 

## 📌 작업 내용 및 특이사항
- Post 엔티티에  UPLOAD_CONFIRMED 상태값 추가 ( 예약시간이 정해진 상태)
-  3가지 옵션 설정 후 이미 예약된 시간을 제외한 시간에 예약시간을 배정
- 1. 하루에 업로드 할 글의 수
- 2. 시간대 (오전, 점심..)
- 3. 업로드 시작 시간

## 로직
- DB에서 READY_TO_UPLOAD(업로드 준비 상태) 글을 가져옴
- DB에서 UPLOAD_CONFIRMED( 업로드 시간 확정 상태) 글을 가져옴
- 이미 업로드 시간 확정 상태인 시간을 제외한 후 랜덤값으로 가능 시간을 가져옴
- displayOrder순서로 가져온 post의 리스트에 순서대로 Upload 가능 시간을 배정

## 🧐 고민한 점
- 

## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- 


