### PR TITLE
[#306] Chore: Twitter기존 client key값으로 로그인

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/v1/sns/twitter/LegacyTwitterController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/v1/sns/twitter/LegacyTwitterController.java
@@ -31,10 +31,9 @@ public class LegacyTwitterController {
 	)
 	@GetMapping("/login")
 	public ResponseEntity<TwitterRedirectResponse> redirectToTwitterAuth(
-		@RequestHeader("Authorization") String accessToken,
-		@RequestBody OAuthClientCredentials clientCredentials
+		@RequestHeader("Authorization") String accessToken
 	) {
-		String url = twitterService.createRedirectResponse(accessToken, clientCredentials);
+		String url = twitterService.createRedirectResponseV1(accessToken);
 		return ResponseEntity.ok(TwitterRedirectResponse.from(url));
 	}
 

--- a/application/main-app/src/main/java/org/mainapp/domain/v1/sns/twitter/TwitterController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/v1/sns/twitter/TwitterController.java
@@ -2,11 +2,9 @@ package org.mainapp.domain.v1.sns.twitter;
 
 import java.io.IOException;
 
-import org.mainapp.domain.v1.sns.twitter.request.OAuthClientCredentials;
 import org.mainapp.domain.v1.sns.twitter.response.TwitterRedirectResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -30,10 +28,9 @@ public class TwitterController {
 	)
 	@GetMapping("/login")
 	public ResponseEntity<TwitterRedirectResponse> redirectToTwitterAuth(
-		@RequestHeader("Authorization") String accessToken,
-		@RequestBody OAuthClientCredentials clientCredentials
+		@RequestHeader("Authorization") String accessToken
 	) {
-		String url = twitterService.createRedirectResponse(accessToken, clientCredentials);
+		String url = twitterService.createRedirectResponseV1(accessToken);
 		return ResponseEntity.ok(TwitterRedirectResponse.from(url));
 	}
 

--- a/application/main-app/src/main/java/org/mainapp/domain/v1/sns/twitter/TwitterService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/v1/sns/twitter/TwitterService.java
@@ -65,4 +65,15 @@ public class TwitterService {
 			throw new CustomException(SnsErrorCode.TWITTER_USER_INFO_FETCH_FAILED);
 		}
 	}
+
+	//TODO 트위터 리펙토링 후 제거
+	/**
+	 * Twitter Authorization URL 생성 및 리다이렉트 ResponseEntity 반환
+	 */
+	public String createRedirectResponseV1(String accessToken) {
+		String redirectUrl = "T0dSSXZOYk15RkdZa2otS3pkOG86MTpjaQ";
+		// 리다이렉트 URL 생성
+		final Long userId = jwtUtil.getUserIdFromAccessToken(accessToken);
+		return twitterApiService.getTwitterAuthorizationUrl(userId.toString(), redirectUrl);
+	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #306 

## 📌 작업 내용 및 특이사항
- 기존 ClientId,Secret 값을 받지 않고 트위터 로그인 방식 롤백
- ClientId는 공개가 가능하기에 임시방편으로 설정

## 🧐 고민한 점
- ClientId, Client Secret으로 바로 변경할 것 같아서 이전 코드를 남겨두지 않고 #289에서 변경을 해버렸네요...
-  develop에 일단은 이전 Twitter login 요청이 가능하도록 변경했어요!
-  만들어주신 LegacyTiwtterController에서 ClientId, ClientSecret을 받지 않도록 수정했어요

## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- 


